### PR TITLE
Feature/distribute to agents

### DIFF
--- a/x/dist/keeper/allocation.go
+++ b/x/dist/keeper/allocation.go
@@ -47,13 +47,7 @@ func (k Keeper) AllocateTokens(
 
 		remainingFees = feesCollected.Sub(proposerReward).Add(proposerRemainder...)
 
-		ctx.EventManager().EmitEvent(
-			sdk.NewEvent(
-				types.EventTypeProposerReward,
-				sdk.NewAttribute(sdk.AttributeKeyAmount, proposerReward.String()),
-				sdk.NewAttribute(types.AttributeKeyValidator, proposerValidator.GetOperator().String()),
-			),
-		)
+		//TODO: emit event for sequencer reward
 	}
 
 	/* ---------------------- reward the agents/validators ---------------------- */
@@ -63,6 +57,7 @@ func (k Keeper) AllocateTokens(
 	agentsRewards := feesCollected.MulDecTruncate(agentsMultipler)
 
 	k.stakingKeeper.IterateBondedValidatorsByPower(ctx, func(index int64, validator stakingtypes.ValidatorI) (stop bool) {
+		//Staking module calculates power factored by sdk.DefaultPowerReduction. hardcoded.
 		valPower := validator.GetConsensusPower(sdk.DefaultPowerReduction)
 		powerFraction := sdk.NewDec(valPower).QuoTruncate(sdk.NewDecFromInt(totalPreviousPower))
 

--- a/x/dist/keeper/allocation_test.go
+++ b/x/dist/keeper/allocation_test.go
@@ -1,8 +1,10 @@
 package keeper_test
 
 import (
+	"fmt"
 	"testing"
 
+	"github.com/dymensionxyz/rollapp/app"
 	"github.com/dymensionxyz/rollapp/testutil/utils"
 
 	"github.com/stretchr/testify/require"
@@ -12,7 +14,11 @@ import (
 	"github.com/cosmos/cosmos-sdk/simapp"
 	sdk "github.com/cosmos/cosmos-sdk/types"
 
+	seqkeeper "github.com/dymensionxyz/rollapp/x/sequencers/keeper"
+	seqtypes "github.com/dymensionxyz/rollapp/x/sequencers/types"
+
 	authtypes "github.com/cosmos/cosmos-sdk/x/auth/types"
+	disttypes "github.com/cosmos/cosmos-sdk/x/distribution/types"
 	"github.com/cosmos/cosmos-sdk/x/staking/teststaking"
 	stakingtypes "github.com/cosmos/cosmos-sdk/x/staking/types"
 )
@@ -27,63 +33,17 @@ var (
 	valConsAddr1 = sdk.ConsAddress(valConsPk1.Address())
 	valConsAddr2 = sdk.ConsAddress(valConsPk2.Address())
 
-	// distrAcc = authtypes.NewEmptyModuleAccount(types.ModuleName)
+	totalFees     = sdk.NewInt(100)
+	totalFeesCoin = sdk.NewCoin(sdk.DefaultBondDenom, totalFees)
+	totalFeesDec  = sdk.NewDecFromInt(totalFees)
 )
 
-func TestAllocateTokensToValidatorWithCommission(t *testing.T) {
-	app := utils.Setup(false)
-	ctx := app.BaseApp.NewContext(false, tmproto.Header{})
+//Test multiple sequencers, each propose a block
 
-	addrs := utils.AddTestAddrs(app, ctx, 3, sdk.NewInt(1234))
-	valAddrs := simapp.ConvertAddrsToValAddrs(addrs)
-	tstaking := teststaking.NewHelper(t, ctx, app.StakingKeeper)
-
-	// create validator with 50% commission
-	tstaking.Commission = stakingtypes.NewCommissionRates(sdk.NewDecWithPrec(5, 1), sdk.NewDecWithPrec(5, 1), sdk.NewDec(0))
-	tstaking.CreateValidator(sdk.ValAddress(addrs[0]), valConsPk1, sdk.NewInt(100), true)
-	val := app.StakingKeeper.Validator(ctx, valAddrs[0])
-
-	// allocate tokens
-	tokens := sdk.DecCoins{
-		{Denom: sdk.DefaultBondDenom, Amount: sdk.NewDec(10)},
-	}
-	app.DistrKeeper.AllocateTokensToValidator(ctx, val, tokens)
-
-	// check commission
-	expected := sdk.DecCoins{
-		{Denom: sdk.DefaultBondDenom, Amount: sdk.NewDec(5)},
-	}
-	require.Equal(t, expected, app.DistrKeeper.GetValidatorAccumulatedCommission(ctx, val.GetOperator()).Commission)
-
-	// check current rewards
-	require.Equal(t, expected, app.DistrKeeper.GetValidatorCurrentRewards(ctx, val.GetOperator()).Rewards)
-}
-
-func TestAllocateTokensToManyValidators(t *testing.T) {
-	app := utils.Setup(false)
-	ctx := app.BaseApp.NewContext(false, tmproto.Header{})
-
-	addrs := utils.AddTestAddrs(app, ctx, 2, sdk.NewInt(1234))
-	valAddrs := simapp.ConvertAddrsToValAddrs(addrs)
-	tstaking := teststaking.NewHelper(t, ctx, app.StakingKeeper)
-
-	// create validator with 50% commission
-	tstaking.Commission = stakingtypes.NewCommissionRates(sdk.NewDecWithPrec(5, 1), sdk.NewDecWithPrec(5, 1), sdk.NewDec(0))
-	tstaking.CreateValidator(valAddrs[0], valConsPk1, sdk.NewInt(100), true)
-
-	// create second validator with 0% commission
-	tstaking.Commission = stakingtypes.NewCommissionRates(sdk.NewDec(0), sdk.NewDec(0), sdk.NewDec(0))
-	tstaking.CreateValidator(valAddrs[1], valConsPk2, sdk.NewInt(100), true)
-
-	abciValA := abci.Validator{
-		Address: valConsPk1.Address(),
-		Power:   100,
-	}
-	abciValB := abci.Validator{
-		Address: valConsPk2.Address(),
-		Power:   100,
-	}
-
+/* -------------------------------------------------------------------------- */
+/*                                    utils                                   */
+/* -------------------------------------------------------------------------- */
+func assertInitial(t *testing.T, ctx sdk.Context, app *app.App, valAddrs []sdk.ValAddress) {
 	// assert initial state: zero outstanding rewards, zero community pool, zero commission, zero current rewards
 	require.True(t, app.DistrKeeper.GetValidatorOutstandingRewards(ctx, valAddrs[0]).Rewards.IsZero())
 	require.True(t, app.DistrKeeper.GetValidatorOutstandingRewards(ctx, valAddrs[1]).Rewards.IsZero())
@@ -92,61 +52,247 @@ func TestAllocateTokensToManyValidators(t *testing.T) {
 	require.True(t, app.DistrKeeper.GetValidatorAccumulatedCommission(ctx, valAddrs[1]).Commission.IsZero())
 	require.True(t, app.DistrKeeper.GetValidatorCurrentRewards(ctx, valAddrs[0]).Rewards.IsZero())
 	require.True(t, app.DistrKeeper.GetValidatorCurrentRewards(ctx, valAddrs[1]).Rewards.IsZero())
+}
 
-	// allocate tokens as if both had voted and second was proposer
-	fees := sdk.NewCoins(sdk.NewCoin(sdk.DefaultBondDenom, sdk.NewInt(100)))
+func fundModules(t *testing.T, ctx sdk.Context, app *app.App) {
+	fees := sdk.NewCoins(totalFeesCoin)
 	feeCollector := app.AccountKeeper.GetModuleAccount(ctx, authtypes.FeeCollectorName)
 	require.NotNil(t, feeCollector)
 
 	// fund fee collector
 	require.NoError(t, simapp.FundModuleAccount(app.BankKeeper, ctx, feeCollector.GetName(), fees))
 	app.AccountKeeper.SetAccount(ctx, feeCollector)
-
-	_ = []abci.VoteInfo{
-		{
-			Validator:       abciValA,
-			SignedLastBlock: true,
-		},
-		{
-			Validator:       abciValB,
-			SignedLastBlock: true,
-		},
-	}
-
-	//First block created by val2
-	app.DistrKeeper.AllocateTokens(ctx, valConsAddr2)
-	//make sure val1 gets nothing (not participating in this block)
-	require.True(t, app.DistrKeeper.GetValidatorCurrentRewards(ctx, valAddrs[0]).Rewards.IsZero())
-	require.True(t, app.DistrKeeper.GetValidatorOutstandingRewards(ctx, valAddrs[0]).Rewards.IsZero())
-	require.True(t, app.DistrKeeper.GetValidatorAccumulatedCommission(ctx, valAddrs[0]).Commission.IsZero())
-
-	// 98 outstanding rewards (100 less 2 to community pool) - all should go to validator 2
-	require.Equal(t, sdk.DecCoins{{Denom: sdk.DefaultBondDenom, Amount: sdk.NewDecWithPrec(980, 1)}}, app.DistrKeeper.GetValidatorOutstandingRewards(ctx, valAddrs[1]).Rewards)
-	require.True(t, app.DistrKeeper.GetValidatorAccumulatedCommission(ctx, valAddrs[1]).Commission.IsZero())
-	require.Equal(t, sdk.DecCoins{{Denom: sdk.DefaultBondDenom, Amount: sdk.NewDecWithPrec(980, 1)}}, app.DistrKeeper.GetValidatorCurrentRewards(ctx, valAddrs[1]).Rewards)
-
-	//2nd block by val1
-	require.NoError(t, simapp.FundModuleAccount(app.BankKeeper, ctx, feeCollector.GetName(), fees))
-	app.AccountKeeper.SetAccount(ctx, feeCollector)
-	app.DistrKeeper.AllocateTokens(ctx, valConsAddr1)
-
-	// 50% commission for first proposer, (0.5 * 98%) * 100 = 49
-	require.Equal(t, sdk.DecCoins{{Denom: sdk.DefaultBondDenom, Amount: sdk.NewDecWithPrec(980, 1)}}, app.DistrKeeper.GetValidatorOutstandingRewards(ctx, valAddrs[0]).Rewards)
-	require.Equal(t, sdk.DecCoins{{Denom: sdk.DefaultBondDenom, Amount: sdk.NewDecWithPrec(490, 1)}}, app.DistrKeeper.GetValidatorAccumulatedCommission(ctx, valAddrs[0]).Commission)
-	require.Equal(t, sdk.DecCoins{{Denom: sdk.DefaultBondDenom, Amount: sdk.NewDecWithPrec(490, 1)}}, app.DistrKeeper.GetValidatorCurrentRewards(ctx, valAddrs[0]).Rewards)
-
-	// 4 community pool coins
-	require.Equal(t, sdk.DecCoins{{Denom: sdk.DefaultBondDenom, Amount: sdk.NewDec(4)}}, app.DistrKeeper.GetFeePool(ctx).CommunityPool)
-
 }
 
+func createSeq(t *testing.T, ctx sdk.Context, app *app.App, valAddr sdk.ValAddress) {
+	// create sequencer
+	msgServ := seqkeeper.NewMsgServerImpl(app.SequencersKeeper)
+	description := stakingtypes.NewDescription(
+		"moniker",
+		"identity",
+		"website",
+		"security",
+		"details",
+	)
+
+	msg, _ := seqtypes.NewMsgCreateSequencer(
+		sdk.ValAddress(valAddr), valConsPk2, description,
+	)
+	msgServ.CreateSequencer(sdk.WrapSDKContext(ctx), msg)
+}
+
+func createValidators(t *testing.T, ctx sdk.Context, app *app.App) []sdk.ValAddress {
+	addrs := utils.AddTestAddrs(app, ctx, 2, sdk.TokensFromConsensusPower(10, sdk.DefaultPowerReduction))
+	valAddrs := simapp.ConvertAddrsToValAddrs(addrs)
+	tstaking := teststaking.NewHelper(t, ctx, app.AgentsKeeper)
+
+	// create validator with 6 power and 50% commission
+	tstaking.Commission = stakingtypes.NewCommissionRates(sdk.NewDecWithPrec(5, 1), sdk.NewDecWithPrec(5, 1), sdk.NewDec(0))
+	tstaking.CreateValidator(valAddrs[0], valConsPk1, sdk.TokensFromConsensusPower(6, sdk.DefaultPowerReduction), true)
+
+	// create second validator with 4 power
+	tstaking.Commission = stakingtypes.NewCommissionRates(sdk.NewDec(0), sdk.NewDec(0), sdk.NewDec(0))
+	tstaking.CreateValidator(valAddrs[1], valConsPk2, sdk.TokensFromConsensusPower(4, sdk.DefaultPowerReduction), true)
+	return valAddrs
+}
+
+/* -------------------------------------------------------------------------- */
+/*                          stakers only, no proposer                         */
+/* -------------------------------------------------------------------------- */
+func TestAllocateTokensValidatorsNoProposer(t *testing.T) {
+	app := utils.Setup(false)
+	ctx := app.BaseApp.NewContext(false, tmproto.Header{})
+
+	valAddrs := createValidators(t, ctx, app)
+	assertInitial(t, ctx, app, valAddrs)
+	fundModules(t, ctx, app)
+
+	// end block to bond validator and start new block
+	_ = app.AgentsKeeper.BlockValidatorUpdates(ctx)
+	ctx = ctx.WithBlockHeight(ctx.BlockHeight() + 1)
+
+	//TODO: test with different params
+	proposerReward := 0.4
+	communityTax := 0.02
+	app.DistrKeeper.SetParams(ctx, disttypes.Params{
+		CommunityTax:        sdk.MustNewDecFromStr(fmt.Sprintf("%f", communityTax)),
+		BaseProposerReward:  sdk.MustNewDecFromStr(fmt.Sprintf("%f", proposerReward)),
+		BonusProposerReward: sdk.MustNewDecFromStr("0"),
+		WithdrawAddrEnabled: false,
+	})
+	// allocate tokens as if both had voted and second was proposer
+	app.DistrKeeper.AllocateTokens(ctx, valConsAddr2)
+
+	/* ------------------------------ Test stakers ------------------------------ */
+	// outstanding rewards: 60% to val1 and 40% to val2
+	//val1 has 50% commission as well
+	stakersFees := totalFeesDec.MulTruncate(sdk.MustNewDecFromStr(fmt.Sprintf("%f", (1 - proposerReward - communityTax))))
+	val1Coins := stakersFees.MulTruncate(sdk.MustNewDecFromStr(fmt.Sprintf("%f", 0.6)))
+	val2Coins := stakersFees.MulTruncate(sdk.MustNewDecFromStr(fmt.Sprintf("%f", 0.4)))
+	val1Commission := val1Coins.Mul(sdk.MustNewDecFromStr(fmt.Sprintf("%f", 0.5)))
+
+	require.Equal(t, sdk.DecCoins{{Denom: sdk.DefaultBondDenom, Amount: val1Coins}}, app.DistrKeeper.GetValidatorOutstandingRewards(ctx, valAddrs[0]).Rewards)
+	require.Equal(t, sdk.DecCoins{{Denom: sdk.DefaultBondDenom, Amount: val2Coins}}, app.DistrKeeper.GetValidatorOutstandingRewards(ctx, valAddrs[1]).Rewards)
+
+	// Check commissions and delegator rewards val1
+	require.Equal(t, sdk.DecCoins{{Denom: sdk.DefaultBondDenom, Amount: val1Commission}}, app.DistrKeeper.GetValidatorAccumulatedCommission(ctx, valAddrs[0]).Commission)
+	require.Equal(t, sdk.DecCoins{{Denom: sdk.DefaultBondDenom, Amount: val1Coins.Sub(val1Commission)}}, app.DistrKeeper.GetValidatorCurrentRewards(ctx, valAddrs[0]).Rewards)
+
+	// Check commissions and delegator rewards val2
+	require.True(t, app.DistrKeeper.GetValidatorAccumulatedCommission(ctx, valAddrs[1]).Commission.IsZero())
+	require.Equal(t, sdk.DecCoins{{Denom: sdk.DefaultBondDenom, Amount: val2Coins}}, app.DistrKeeper.GetValidatorCurrentRewards(ctx, valAddrs[1]).Rewards)
+
+	/* ------------------------ Test community pool coins ----------------------- */
+	minCommunityFund := totalFeesDec.MulTruncate(sdk.MustNewDecFromStr(fmt.Sprintf("%f", communityTax)))
+	communityBalance := app.DistrKeeper.GetFeePool(ctx).CommunityPool.AmountOf(sdk.DefaultBondDenom)
+	require.True(t, communityBalance.GTE(minCommunityFund))
+
+	leftoverFees := totalFeesDec.Sub(val1Coins).Sub(val2Coins)
+	if leftoverFees.IsPositive() {
+		require.Equal(t, leftoverFees, communityBalance)
+	}
+
+	if app.DistrKeeper.GetFeePool(ctx).CommunityPool.IsZero() {
+		require.True(t, communityTax == 0)
+	}
+}
+
+/* -------------------------------------------------------------------------- */
+/*                          proposer only, no stakers                         */
+/* -------------------------------------------------------------------------- */
+func TestAllocateTokensToProposerNoValidators(t *testing.T) {
+	app := utils.Setup(false)
+	ctx := app.BaseApp.NewContext(false, tmproto.Header{})
+
+	addrs := utils.AddTestAddrs(app, ctx, 2, sdk.TokensFromConsensusPower(10, sdk.DefaultPowerReduction))
+	valAddrs := simapp.ConvertAddrsToValAddrs(addrs)
+
+	fundModules(t, ctx, app)
+
+	// create sequencer
+	createSeq(t, ctx, app, valAddrs[1])
+
+	proposerReward := 0.4
+	communityTax := 0.02
+	app.DistrKeeper.SetParams(ctx, disttypes.Params{
+		CommunityTax:        sdk.MustNewDecFromStr(fmt.Sprintf("%f", communityTax)),
+		BaseProposerReward:  sdk.MustNewDecFromStr(fmt.Sprintf("%f", proposerReward)),
+		BonusProposerReward: sdk.MustNewDecFromStr("0"),
+		WithdrawAddrEnabled: false,
+	})
+	// allocate tokens as if both had voted and second was proposer
+	app.DistrKeeper.AllocateTokens(ctx, valConsAddr2)
+
+	/* ------------------------- Test proposer rewards ------------------------ */
+	proposerFees := totalFeesDec.MulTruncate(sdk.MustNewDecFromStr(fmt.Sprintf("%f", proposerReward)))
+
+	initialBalance := sdk.TokensFromConsensusPower(10, sdk.DefaultPowerReduction)
+	currentBalance := app.BankKeeper.GetAllBalances(ctx, sdk.AccAddress(valAddrs[1]))
+	//expected = initial + proposer fees
+	expectedBalance := initialBalance.Add(proposerFees.RoundInt())
+	expectedCoins := sdk.NewCoins(sdk.NewCoin(sdk.DefaultBondDenom, expectedBalance))
+
+	require.Equal(t, expectedCoins, currentBalance)
+
+	/* ------------------------ Test community pool coins ----------------------- */
+	minCommunityFund := totalFeesDec.MulTruncate(sdk.MustNewDecFromStr(fmt.Sprintf("%f", communityTax)))
+	communityBalance := app.DistrKeeper.GetFeePool(ctx).CommunityPool.AmountOf(sdk.DefaultBondDenom)
+	require.True(t, communityBalance.GTE(minCommunityFund))
+
+	leftoverFees := totalFeesDec.Sub(proposerFees)
+	if leftoverFees.IsPositive() {
+		require.Equal(t, leftoverFees, communityBalance)
+	}
+
+	if app.DistrKeeper.GetFeePool(ctx).CommunityPool.IsZero() {
+		require.True(t, communityTax == 0)
+	}
+}
+
+/* -------------------------------------------------------------------------- */
+/*                          both proposer and agents                          */
+/* -------------------------------------------------------------------------- */
+func TestAllocateTokensValidatorsAndProposer(t *testing.T) {
+	app := utils.Setup(false)
+	ctx := app.BaseApp.NewContext(false, tmproto.Header{})
+
+	valAddrs := createValidators(t, ctx, app)
+	assertInitial(t, ctx, app, valAddrs)
+	fundModules(t, ctx, app)
+
+	// end block to bond validator and start new block
+	_ = app.AgentsKeeper.BlockValidatorUpdates(ctx)
+	ctx = ctx.WithBlockHeight(ctx.BlockHeight() + 1)
+
+	// create sequencer
+	createSeq(t, ctx, app, valAddrs[1])
+
+	proposerReward := 0.4
+	communityTax := 0.02
+	app.DistrKeeper.SetParams(ctx, disttypes.Params{
+		CommunityTax:        sdk.MustNewDecFromStr(fmt.Sprintf("%f", communityTax)),
+		BaseProposerReward:  sdk.MustNewDecFromStr(fmt.Sprintf("%f", proposerReward)),
+		BonusProposerReward: sdk.MustNewDecFromStr("0"),
+		WithdrawAddrEnabled: false,
+	})
+	// allocate tokens as if both had voted and second was proposer
+	app.DistrKeeper.AllocateTokens(ctx, valConsAddr2)
+
+	/* ------------------------- Test proposer rewards ------------------------ */
+	proposerFees := totalFeesDec.MulTruncate(sdk.MustNewDecFromStr(fmt.Sprintf("%f", proposerReward)))
+
+	initialBalance := sdk.TokensFromConsensusPower(10, sdk.DefaultPowerReduction)
+	currentBalance := app.BankKeeper.GetAllBalances(ctx, sdk.AccAddress(valAddrs[1]))
+	//expected = initial + proposer fees - staked amount
+	expectedBalance := initialBalance.Add(proposerFees.RoundInt()).Sub(sdk.TokensFromConsensusPower(4, sdk.DefaultPowerReduction))
+	expectedCoins := sdk.NewCoins(sdk.NewCoin(sdk.DefaultBondDenom, expectedBalance))
+
+	require.Equal(t, expectedCoins, currentBalance)
+
+	/* ------------------------------ Test stakers ------------------------------ */
+	// outstanding rewards: 60% to val1 and 40% to val2
+	//val1 has 50% commission as well
+	stakersFees := totalFeesDec.MulTruncate(sdk.MustNewDecFromStr(fmt.Sprintf("%f", (1 - proposerReward - communityTax))))
+	val1Coins := stakersFees.MulTruncate(sdk.MustNewDecFromStr(fmt.Sprintf("%f", 0.6)))
+	val2Coins := stakersFees.MulTruncate(sdk.MustNewDecFromStr(fmt.Sprintf("%f", 0.4)))
+	val1Commission := val1Coins.Mul(sdk.MustNewDecFromStr(fmt.Sprintf("%f", 0.5)))
+
+	require.Equal(t, sdk.DecCoins{{Denom: sdk.DefaultBondDenom, Amount: val1Coins}}, app.DistrKeeper.GetValidatorOutstandingRewards(ctx, valAddrs[0]).Rewards)
+	require.Equal(t, sdk.DecCoins{{Denom: sdk.DefaultBondDenom, Amount: val2Coins}}, app.DistrKeeper.GetValidatorOutstandingRewards(ctx, valAddrs[1]).Rewards)
+
+	// Check commissions and delegator rewards val1
+	require.Equal(t, sdk.DecCoins{{Denom: sdk.DefaultBondDenom, Amount: val1Commission}}, app.DistrKeeper.GetValidatorAccumulatedCommission(ctx, valAddrs[0]).Commission)
+	require.Equal(t, sdk.DecCoins{{Denom: sdk.DefaultBondDenom, Amount: val1Coins.Sub(val1Commission)}}, app.DistrKeeper.GetValidatorCurrentRewards(ctx, valAddrs[0]).Rewards)
+
+	// Check commissions and delegator rewards val2
+	require.True(t, app.DistrKeeper.GetValidatorAccumulatedCommission(ctx, valAddrs[1]).Commission.IsZero())
+	require.Equal(t, sdk.DecCoins{{Denom: sdk.DefaultBondDenom, Amount: val2Coins}}, app.DistrKeeper.GetValidatorCurrentRewards(ctx, valAddrs[1]).Rewards)
+
+	/* ------------------------ Test community pool coins ----------------------- */
+	minCommunityFund := totalFeesDec.MulTruncate(sdk.MustNewDecFromStr(fmt.Sprintf("%f", communityTax)))
+	communityBalance := app.DistrKeeper.GetFeePool(ctx).CommunityPool.AmountOf(sdk.DefaultBondDenom)
+	require.True(t, communityBalance.GTE(minCommunityFund))
+
+	leftoverFees := totalFeesDec.Sub(proposerFees).Sub(val1Coins).Sub(val2Coins)
+	if leftoverFees.IsPositive() {
+		require.Equal(t, leftoverFees, communityBalance)
+	}
+
+	if app.DistrKeeper.GetFeePool(ctx).CommunityPool.IsZero() {
+		require.True(t, communityTax == 0)
+	}
+}
+
+/* -------------------------------------------------------------------------- */
+/*                               original tests                               */
+/* -------------------------------------------------------------------------- */
 func TestAllocateTokensTruncation(t *testing.T) {
 	app := utils.Setup(false)
 	ctx := app.BaseApp.NewContext(false, tmproto.Header{})
 
 	addrs := utils.AddTestAddrs(app, ctx, 3, sdk.NewInt(1234))
 	valAddrs := simapp.ConvertAddrsToValAddrs(addrs)
-	tstaking := teststaking.NewHelper(t, ctx, app.StakingKeeper)
+	tstaking := teststaking.NewHelper(t, ctx, app.AgentsKeeper)
 
 	// create validator with 10% commission
 	tstaking.Commission = stakingtypes.NewCommissionRates(sdk.NewDecWithPrec(1, 1), sdk.NewDecWithPrec(1, 1), sdk.NewDec(0))
@@ -212,4 +358,33 @@ func TestAllocateTokensTruncation(t *testing.T) {
 	require.True(t, app.DistrKeeper.GetValidatorOutstandingRewards(ctx, valAddrs[0]).Rewards.IsValid())
 	require.True(t, app.DistrKeeper.GetValidatorOutstandingRewards(ctx, valAddrs[1]).Rewards.IsValid())
 	require.True(t, app.DistrKeeper.GetValidatorOutstandingRewards(ctx, valAddrs[2]).Rewards.IsValid())
+}
+
+func TestAllocateTokensToValidatorWithCommission(t *testing.T) {
+	app := utils.Setup(false)
+	ctx := app.BaseApp.NewContext(false, tmproto.Header{})
+
+	addrs := utils.AddTestAddrs(app, ctx, 3, sdk.NewInt(1234))
+	valAddrs := simapp.ConvertAddrsToValAddrs(addrs)
+	tstaking := teststaking.NewHelper(t, ctx, app.AgentsKeeper)
+
+	// create validator with 50% commission
+	tstaking.Commission = stakingtypes.NewCommissionRates(sdk.NewDecWithPrec(5, 1), sdk.NewDecWithPrec(5, 1), sdk.NewDec(0))
+	tstaking.CreateValidator(sdk.ValAddress(addrs[0]), valConsPk1, sdk.NewInt(100), true)
+	val := app.AgentsKeeper.Validator(ctx, valAddrs[0])
+
+	// allocate tokens
+	tokens := sdk.DecCoins{
+		{Denom: sdk.DefaultBondDenom, Amount: sdk.NewDec(10)},
+	}
+	app.DistrKeeper.AllocateTokensToValidator(ctx, val, tokens)
+
+	// check commission
+	expected := sdk.DecCoins{
+		{Denom: sdk.DefaultBondDenom, Amount: sdk.NewDec(5)},
+	}
+	require.Equal(t, expected, app.DistrKeeper.GetValidatorAccumulatedCommission(ctx, val.GetOperator()).Commission)
+
+	// check current rewards
+	require.Equal(t, expected, app.DistrKeeper.GetValidatorCurrentRewards(ctx, val.GetOperator()).Rewards)
 }


### PR DESCRIPTION
Distribution module distribute rewards to **both** sequencer and stakers


Sequencer's rewards are distributed immediately to the sequencer account
Agents rewards distributed the same as staking module in vanilla SDK

All remaining fees goes to community
(i.e if no validators available, or sequencer not registered, their designated fees goes to community)