### PR TITLE
chore: remove the override of the expected chain id in EVM module

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -132,8 +132,7 @@ install_evm: build_evm go.sum ## Install the rollapp_evm binary
 
 .PHONY: build_evm
 build_evm: ## Compiles the rollapp_evm binary
-	$(eval BUILD_FLAGS+=-ldflags '-X github.com/cosmos/cosmos-sdk/version.AppName=rollapp_evm \
-  -X github.com/evmos/ethermint/types.regexEpochSeparator=_')
+	$(eval BUILD_FLAGS+=-ldflags '-X github.com/cosmos/cosmos-sdk/version.AppName=rollapp_evm')
 	go build -o build/rollapp_evm $(BUILD_FLAGS) -tags evm ./cmd/evm
 
 # ---------------------------------------------------------------------------- #


### PR DESCRIPTION
Currently we override the expected chain-id format from `XXXX_000-00` to `XXXX_0000_00`

This PR removes this override, and the expected chain-id for a rollapp is the standard convention `XXXX_000-00`

# PR Standards

## Opening a pull request should be able to meet the following requirements

---

For Author:

- [ ]  Targeted PR against correct branch
- [ ]  included the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
- [ ]  Linked to Github issue with discussion and accepted design
- [ ]  Targets only one github issue
- [ ]  Wrote unit and integration tests
- [ ]  All CI checks have passed
- [ ]  Added relevant `godoc` [comments](https://blog.golang.org/godoc-documenting-go-code)

---

For Reviewer:

- [ ]  confirmed the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
- [ ]  Reviewers assigned
- [ ]  confirmed all author checklist items have been addressed

---

After reviewer approval:

- [ ]  In case targets main branch, PR should be squashed and merged.
- [ ]  In case PR targets a release branch, PR should be rebased.
