### PR TITLE
feat: support stakers on genesis

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -8,7 +8,7 @@ require (
 	github.com/cosmos/cosmos-sdk v0.46.13
 	github.com/cosmos/ibc-go/v6 v6.1.1
 	github.com/dymensionxyz/dymint v0.5.0-rc4
-	github.com/dymensionxyz/rollapp v0.0.0-20230724112726-f9219f1e8984
+	github.com/dymensionxyz/rollapp v0.0.0-20230809150048-b0c1bb3e880f
 	github.com/gogo/protobuf v1.3.3
 	github.com/golang/protobuf v1.5.3
 	github.com/gorilla/mux v1.8.0

--- a/go.sum
+++ b/go.sum
@@ -477,8 +477,8 @@ github.com/dymensionxyz/dymint v0.5.0-rc4 h1:wx6Be6O8rtOf+klDAMwv+tbfiJiyKEqiK69
 github.com/dymensionxyz/dymint v0.5.0-rc4/go.mod h1:wwYbbeqhzANMDbpAaZLTTpypDvfQmt0+WuIiaT3xWQk=
 github.com/dymensionxyz/ibc-go/v6 v6.0.0-rc0.0.20230619115257-1a1038e16d71 h1:T04fab8CTYu+FR6mAC/nYB78WtHM4YsI99ikrYydncM=
 github.com/dymensionxyz/ibc-go/v6 v6.0.0-rc0.0.20230619115257-1a1038e16d71/go.mod h1:CY3zh2HLfetRiW8LY6kVHMATe90Wj/UOoY8T6cuB0is=
-github.com/dymensionxyz/rollapp v0.0.0-20230724112726-f9219f1e8984 h1:b8U9zGkQBNf4iosdKlSyXFXvLVeDDwA1HY1PoRHDnBQ=
-github.com/dymensionxyz/rollapp v0.0.0-20230724112726-f9219f1e8984/go.mod h1:dvkiTtE+VzeTqAyuBNwqSeYOQA5GTLpMqO6S/KQSRtU=
+github.com/dymensionxyz/rollapp v0.0.0-20230809150048-b0c1bb3e880f h1:9lZtf57KUjr5FIoH2HAdGKG2MrxTjMymkfWEESYSHfw=
+github.com/dymensionxyz/rollapp v0.0.0-20230809150048-b0c1bb3e880f/go.mod h1:NwpAQmeMr5ihwwMNVNeIFFdSQkzL3W8cgizIDiKwTgk=
 github.com/eapache/go-resiliency v1.1.0/go.mod h1:kFI+JgMyC7bLPUVY133qvEBtVayf5mFgVsvEsIPBvNs=
 github.com/eapache/go-xerial-snappy v0.0.0-20180814174437-776d5712da21/go.mod h1:+020luEh2TKB4/GOp8oxxtq0Daoen/Cii55CzbTV6DU=
 github.com/eapache/queue v1.1.0/go.mod h1:6eCeP0CKFpHLu8blIFXhExK/dRa7WDZfr6jVFPTqq+I=

--- a/x/dist/keeper/allocation_test.go
+++ b/x/dist/keeper/allocation_test.go
@@ -90,14 +90,14 @@ func createSeq(t *testing.T, ctx sdk.Context, app *app.App, valAddr sdk.ValAddre
 func createValidators(t *testing.T, ctx sdk.Context, app *app.App) []sdk.ValAddress {
 	addrs := utils.AddTestAddrs(app, ctx, 2, sdk.TokensFromConsensusPower(10, sdk.DefaultPowerReduction))
 	valAddrs := simapp.ConvertAddrsToValAddrs(addrs)
-	tstaking := teststaking.NewHelper(t, ctx, app.StakingKeeper)
+	tstaking := teststaking.NewHelper(t, ctx, app.StakingKeeper.Keeper)
 
 	// create validator with 6 power and 50% commission
 	tstaking.Commission = stakingtypes.NewCommissionRates(sdk.NewDecWithPrec(5, 1), sdk.NewDecWithPrec(5, 1), sdk.NewDec(0))
 	coin := sdk.NewCoin(sdk.DefaultBondDenom, sdk.TokensFromConsensusPower(6, sdk.DefaultPowerReduction))
 	msg, err := stakingtypes.NewMsgCreateValidator(valAddrs[0], valConsPk1, coin, stakingtypes.Description{}, tstaking.Commission, sdk.OneInt())
 	require.NoError(t, err)
-	_, err = stakingkeeper.NewMsgServerImpl(app.StakingKeeper).CreateValidator(ctx, msg)
+	_, err = stakingkeeper.NewMsgServerImpl(app.StakingKeeper.Keeper).CreateValidator(ctx, msg)
 	require.NoError(t, err)
 
 	// create second validator with 4 power and 10% commision
@@ -105,7 +105,7 @@ func createValidators(t *testing.T, ctx sdk.Context, app *app.App) []sdk.ValAddr
 	coin = sdk.NewCoin(sdk.DefaultBondDenom, sdk.TokensFromConsensusPower(4, sdk.DefaultPowerReduction))
 	msg, err = stakingtypes.NewMsgCreateValidator(valAddrs[1], valConsPk2, coin, stakingtypes.Description{}, tstaking.Commission, sdk.OneInt())
 	require.NoError(t, err)
-	_, err = stakingkeeper.NewMsgServerImpl(app.StakingKeeper).CreateValidator(ctx, msg)
+	_, err = stakingkeeper.NewMsgServerImpl(app.StakingKeeper.Keeper).CreateValidator(ctx, msg)
 	require.NoError(t, err)
 	return valAddrs
 }
@@ -310,7 +310,7 @@ func TestAllocateTokensTruncation(t *testing.T) {
 
 	addrs := utils.AddTestAddrs(app, ctx, 3, sdk.NewInt(1234))
 	valAddrs := simapp.ConvertAddrsToValAddrs(addrs)
-	tstaking := teststaking.NewHelper(t, ctx, app.StakingKeeper)
+	tstaking := teststaking.NewHelper(t, ctx, app.StakingKeeper.Keeper)
 
 	// create validator with 10% commission
 	tstaking.Commission = stakingtypes.NewCommissionRates(sdk.NewDecWithPrec(1, 1), sdk.NewDecWithPrec(1, 1), sdk.NewDec(0))
@@ -384,7 +384,7 @@ func TestAllocateTokensToValidatorWithCommission(t *testing.T) {
 
 	addrs := utils.AddTestAddrs(app, ctx, 3, sdk.NewInt(1234))
 	valAddrs := simapp.ConvertAddrsToValAddrs(addrs)
-	tstaking := teststaking.NewHelper(t, ctx, app.StakingKeeper)
+	tstaking := teststaking.NewHelper(t, ctx, app.StakingKeeper.Keeper)
 
 	// create validator with 50% commission
 	tstaking.Commission = stakingtypes.NewCommissionRates(sdk.NewDecWithPrec(5, 1), sdk.NewDecWithPrec(5, 1), sdk.NewDec(0))

--- a/x/dist/module.go
+++ b/x/dist/module.go
@@ -13,8 +13,6 @@ import (
 	"github.com/cosmos/cosmos-sdk/x/distribution"
 	"github.com/cosmos/cosmos-sdk/x/distribution/types"
 	"github.com/dymensionxyz/dymension-rdk/x/dist/keeper"
-
-	stakingkeeper "github.com/cosmos/cosmos-sdk/x/staking/keeper"
 )
 
 var (
@@ -41,7 +39,7 @@ type AppModule struct {
 // NewAppModule creates a new AppModule object using the native x/distribution AppModule constructor.
 func NewAppModule(
 	cdc codec.Codec, keeper keeper.Keeper, ak types.AccountKeeper,
-	bk types.BankKeeper, sk stakingkeeper.Keeper,
+	bk types.BankKeeper, sk types.StakingKeeper,
 ) AppModule {
 	distAppMod := distribution.NewAppModule(cdc, keeper.Keeper, ak, bk, sk)
 	return AppModule{

--- a/x/staking/keeper/keeper.go
+++ b/x/staking/keeper/keeper.go
@@ -1,0 +1,48 @@
+package keeper
+
+import (
+	sdk "github.com/cosmos/cosmos-sdk/types"
+	abci "github.com/tendermint/tendermint/abci/types"
+
+	storetypes "github.com/cosmos/cosmos-sdk/store/types"
+
+	"github.com/cosmos/cosmos-sdk/codec"
+	paramtypes "github.com/cosmos/cosmos-sdk/x/params/types"
+	stakingkeeper "github.com/cosmos/cosmos-sdk/x/staking/keeper"
+	"github.com/cosmos/cosmos-sdk/x/staking/types"
+)
+
+// Implements ValidatorSet interface
+var _ types.ValidatorSet = Keeper{}
+
+// Implements DelegationSet interface
+var _ types.DelegationSet = Keeper{}
+
+// keeper of the staking store
+type Keeper struct {
+	stakingkeeper.Keeper
+}
+
+// NewKeeper creates a new staking Keeper instance
+func NewKeeper(
+	cdc codec.BinaryCodec, key storetypes.StoreKey, ak types.AccountKeeper, bk types.BankKeeper,
+	ps paramtypes.Subspace,
+) Keeper {
+	k := stakingkeeper.NewKeeper(cdc, key, ak, bk, ps)
+	return Keeper{
+		Keeper: k,
+	}
+}
+
+// Override this function, which is called by genutil when the genesis state is created
+// We don't want to return the validator set
+func (k Keeper) ApplyAndReturnValidatorSetUpdates(ctx sdk.Context) (updates []abci.ValidatorUpdate, err error) {
+	_, err = k.Keeper.ApplyAndReturnValidatorSetUpdates(ctx)
+	return updates, err
+}
+
+// Set the validator hooks
+func (k *Keeper) SetHooks(sh types.StakingHooks) *Keeper {
+	k.Keeper = *k.Keeper.SetHooks(sh)
+	return k
+}

--- a/x/staking/module.go
+++ b/x/staking/module.go
@@ -1,6 +1,8 @@
 package staking
 
 import (
+	"encoding/json"
+
 	abci "github.com/tendermint/tendermint/abci/types"
 
 	sdk "github.com/cosmos/cosmos-sdk/types"
@@ -9,8 +11,7 @@ import (
 	"github.com/cosmos/cosmos-sdk/types/module"
 	"github.com/cosmos/cosmos-sdk/x/staking"
 	"github.com/cosmos/cosmos-sdk/x/staking/types"
-
-	"github.com/cosmos/cosmos-sdk/x/staking/keeper"
+	"github.com/dymensionxyz/dymension-rdk/x/staking/keeper"
 )
 
 var (
@@ -31,12 +32,19 @@ type AppModule struct {
 // NewAppModule creates a new AppModule object
 func NewAppModule(cdc codec.Codec, keeper keeper.Keeper, ak types.AccountKeeper, bk types.BankKeeper) AppModule {
 	return AppModule{
-		AppModule: staking.NewAppModule(cdc, keeper, ak, bk),
+		AppModule: staking.NewAppModule(cdc, keeper.Keeper, ak, bk),
 		keeper:    keeper,
 	}
 }
 
 func (am AppModule) EndBlock(ctx sdk.Context, _ abci.RequestEndBlock) []abci.ValidatorUpdate {
-	_ = staking.EndBlocker(ctx, am.keeper)
+	_ = staking.EndBlocker(ctx, am.keeper.Keeper)
+	return []abci.ValidatorUpdate{}
+}
+
+func (am AppModule) InitGenesis(ctx sdk.Context, cdc codec.JSONCodec, data json.RawMessage) []abci.ValidatorUpdate {
+	var genesisState types.GenesisState
+	cdc.MustUnmarshalJSON(data, &genesisState)
+	_ = am.keeper.InitGenesis(ctx, &genesisState)
 	return []abci.ValidatorUpdate{}
 }


### PR DESCRIPTION
RDK's `staking` module overwrites original's `ApplyAndReturnValidatorSetUpdates` method.
this method called by `genutil` on genesis and returns the validators over ABCI

as we set the validators on the `sequencers` module, we override this method to **not** return the validators set


# PR Standards

## Opening a pull request should be able to meet the following requirements

---

For Author:

- [ ]  Targeted PR against correct branch
- [ ]  included the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
- [ ]  Linked to Github issue with discussion and accepted design
- [ ]  Targets only one github issue
- [ ]  Wrote unit and integration tests
- [ ]  All CI checks have passed
- [ ]  Added relevant `godoc` [comments](https://blog.golang.org/godoc-documenting-go-code)

---

For Reviewer:

- [ ]  confirmed the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
- [ ]  Reviewers assigned
- [ ]  confirmed all author checklist items have been addressed

---

After reviewer approval:

- [ ]  In case targets main branch, PR should be squashed and merged.
- [ ]  In case PR targets a release branch, PR should be rebased.
