### PR TITLE
chore(docs/static/openapi.yml): typo fix

### DIFF
--- a/docs/static/openapi.yml
+++ b/docs/static/openapi.yml
@@ -30950,7 +30950,7 @@ paths:
                               identifier
                         description: >-
                           Version defines the versioning scheme used to
-                          negotiate the IBC verison in
+                          negotiate the IBC version in
 
                           the connection handshake.
                       title: >-
@@ -31339,7 +31339,7 @@ paths:
                             identifier
                       description: >-
                         Version defines the versioning scheme used to negotiate
-                        the IBC verison in
+                        the IBC version in
 
                         the connection handshake.
                     description: >-
@@ -39548,7 +39548,7 @@ definitions:
     type: object
     properties:
       commission:
-        description: commission defines the commision the validator received.
+        description: commission defines the commission the validator received.
         type: object
         properties:
           commission:
@@ -46229,7 +46229,7 @@ definitions:
       gas to be used by the transaction. The ratio yields an effective
       "gasprice",
 
-      which must be above some miminum to be accepted into the mempool.
+      which must be above some minimum to be accepted into the mempool.
   cosmos.tx.v1beta1.GetBlockWithTxsResponse:
     type: object
     properties:
@@ -53929,7 +53929,7 @@ definitions:
               title: list of features compatible with the specified identifier
           description: >-
             Version defines the versioning scheme used to negotiate the IBC
-            verison in
+            version in
 
             the connection handshake.
         description: >-
@@ -54051,7 +54051,7 @@ definitions:
               title: list of features compatible with the specified identifier
           description: >-
             Version defines the versioning scheme used to negotiate the IBC
-            verison in
+            version in
 
             the connection handshake.
         title: >-
@@ -54606,7 +54606,7 @@ definitions:
                   title: list of features compatible with the specified identifier
               description: >-
                 Version defines the versioning scheme used to negotiate the IBC
-                verison in
+                version in
 
                 the connection handshake.
             description: >-
@@ -54743,7 +54743,7 @@ definitions:
                     title: list of features compatible with the specified identifier
                 description: >-
                   Version defines the versioning scheme used to negotiate the
-                  IBC verison in
+                  IBC version in
 
                   the connection handshake.
               title: >-
@@ -54888,7 +54888,7 @@ definitions:
           type: string
         title: list of features compatible with the specified identifier
     description: |-
-      Version defines the versioning scheme used to negotiate the IBC verison in
+      Version defines the versioning scheme used to negotiate the IBC version in
       the connection handshake.
   tendermint.spn.monitoringp.ConnectionChannelID:
     type: object

--- a/docs/static/openapi.yml
+++ b/docs/static/openapi.yml
@@ -6671,7 +6671,7 @@ paths:
             type: object
             properties:
               commission:
-                description: commission defines the commision the validator received.
+                description: commission defines the commission the validator received.
                 type: object
                 properties:
                   commission:
@@ -11115,7 +11115,7 @@ paths:
           type: string
           format: uint64
         - name: voter
-          description: voter defines the oter address for the proposals.
+          description: voter defines the other address for the proposals.
           in: path
           required: true
           type: string
@@ -20147,7 +20147,7 @@ paths:
         - Query
   /cosmwasm/wasm/v1/code/{code_id}:
     get:
-      summary: Code gets the binary code and metadata for a singe wasm code
+      summary: Code gets the binary code and metadata for a single wasm code
       operationId: CosmwasmWasmV1Code
       responses:
         '200':


### PR DESCRIPTION
Fixed few typo in the openapi.yml file from the docs. Those are minor changes. Have a nice evening.
