### PR TITLE
feat(server): add helper to set default pruning settings on the rdk level

### DIFF
--- a/server/config/config.go
+++ b/server/config/config.go
@@ -1,0 +1,13 @@
+package config
+
+import (
+	pruningtypes "github.com/cosmos/cosmos-sdk/pruning/types"
+	"github.com/cosmos/cosmos-sdk/server/config"
+)
+
+func SetDefaultPruningSettings(cfg *config.Config) {
+	cfg.Pruning = pruningtypes.PruningOptionNothing
+	cfg.PruningInterval = "10"
+	cfg.PruningKeepRecent = "100"
+	cfg.MinRetainBlocks = 10000
+}


### PR DESCRIPTION
Default to no pruning
With default values when pruning is enabled set to keep 10k blocks, prune states older then 100 at an interval of 10 states

# PR Standards

## Opening a pull request should be able to meet the following requirements

---

Closes #XXX

**All** items are required. Please add a note to the item if the item is not applicable and
please add links to any relevant follow-up issues.

For Author:

- [ ]  Targeted PR against correct branch
- [ ]  included the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
- [ ]  Linked to Github issue with discussion and accepted design
- [ ]  Targets only one github issue
- [ ]  Wrote unit and integration tests
- [ ]  All CI checks have passed
- [ ]  Added relevant `godoc` [comments](https://blog.golang.org/godoc-documenting-go-code)

---

For Reviewer:

- [ ]  confirmed the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
- [ ]  Reviewers assigned
- [ ]  confirmed all author checklist items have been addressed

---

After reviewer approval:

- [ ]  In case targets main branch, PR should be squashed and merged.
- [ ]  In case PR targets a release branch, PR should be rebased.
