### PR TITLE
feat(genesisbridge): genesis bridge retries

### DIFF
--- a/testutil/app/app.go
+++ b/testutil/app/app.go
@@ -468,6 +468,7 @@ func NewRollapp(
 		app.AccountKeeper,
 		app.BankKeeper,
 		app.MintKeeper,
+		nil,
 	)
 
 	// The IBC tranfer submit is wrapped with:
@@ -504,12 +505,14 @@ func NewRollapp(
 		app.HubKeeper,
 		denommetadatamoduletypes.NewMultiDenommetadataHooks(),
 	)
-	transferStack = hubgenkeeper.NewIBCModule(
+	gbBridgeMiddleware := hubgenkeeper.NewIBCModule(
 		transferStack,
 		app.HubGenesisKeeper,
 		app.BankKeeper,
 		app.IBCKeeper.ChannelKeeper,
 	)
+	app.HubGenesisKeeper.SetICS4Submitter(gbBridgeMiddleware)
+	transferStack = gbBridgeMiddleware
 
 	app.GaslessKeeper = gaslesskeeper.NewKeeper(
 		appCodec,

--- a/x/denommetadata/ibc_middleware.go
+++ b/x/denommetadata/ibc_middleware.go
@@ -65,7 +65,7 @@ func (m *ICS4Wrapper) SendPacket(
 	}
 
 	// don't send metadata on non-canonical channels
-	if hubGenState := m.getHubGenState(ctx); !hubGenState.IsCanonicalHubTransferChannel(destinationPort, destinationChannel) {
+	if hubGenState := m.getHubGenState(ctx); !hubGenState.IsCanonicalBridgeChannel(destinationPort, destinationChannel) {
 		return m.ICS4Wrapper.SendPacket(ctx, chanCap, destinationPort, destinationChannel, timeoutHeight, timeoutTimestamp, data)
 	}
 

--- a/x/hub-genesis/keeper/genesis_transfer.go
+++ b/x/hub-genesis/keeper/genesis_transfer.go
@@ -103,7 +103,7 @@ func (k Keeper) ResubmitPendingGenesisBridges(ctx sdk.Context) {
 		}
 
 		// disable further retries
-		err = k.SetPendingChannel(ctx, portChan, false)
+		err = k.SetPendingChannel(ctx, portChan, types.WaitingForAck)
 		if err != nil {
 			k.Logger(ctx).Error("failed to disable further retries", "port", portChan.Port, "channel", portChan.Channel, "error", err)
 			return false, nil

--- a/x/hub-genesis/keeper/genesis_transfer.go
+++ b/x/hub-genesis/keeper/genesis_transfer.go
@@ -63,7 +63,8 @@ func (k Keeper) EscrowGenesisTransferFunds(ctx sdk.Context, portID, channelID st
 
 // enableBridge enables the bridge after successful genesis bridge phase.
 // It sets the canonical transfer channel and enables outbound transfers
-func (k Keeper) enableBridge(ctx sdk.Context, state types.State, portID, channelID string) {
+func (k Keeper) enableBridge(ctx sdk.Context, portID, channelID string) {
+	state := k.GetState(ctx)
 	state.SetCanonicalBridgeChannel(portID, channelID)
 	state.OutboundTransfersEnabled = true
 	k.SetState(ctx, state)

--- a/x/hub-genesis/keeper/genesis_transfer.go
+++ b/x/hub-genesis/keeper/genesis_transfer.go
@@ -112,7 +112,6 @@ func (k Keeper) ResubmitPendingGenesisBridges(ctx sdk.Context) {
 		k.Logger(ctx).Info("resubmitted genesis bridge data", "sequence", seq, "port", portChan.Port, "channel", portChan.Channel)
 		return false, nil
 	})
-
 	if err != nil {
 		k.Logger(ctx).Error("failed to resubmit genesis bridge data", "error", err)
 	}

--- a/x/hub-genesis/keeper/ibc_module.go
+++ b/x/hub-genesis/keeper/ibc_module.go
@@ -13,9 +13,10 @@ import (
 	"github.com/tendermint/tendermint/libs/log"
 
 	"github.com/dymensionxyz/dymension-rdk/x/hub-genesis/types"
+	"github.com/dymensionxyz/gerr-cosmos/gerrc"
 )
 
-var transferTimeout = (time.Hour) // we use short timeout as we have retry mechanism
+var transferTimeout = (time.Duration(24*365) * time.Hour) // very long timeout
 
 type IBCModule struct {
 	porttypes.IBCModule
@@ -81,14 +82,6 @@ func (w IBCModule) SubmitGenesisBridgeData(ctx sdk.Context, portID string, chann
 		return 0, errorsmod.Wrap(err, "prepare genesis bridge data")
 	}
 
-	if data.GenesisTransfer != nil {
-		// As we don't use the `ibc/transfer` module, we need to handle the funds escrow ourselves
-		err = w.k.EscrowGenesisTransferFunds(ctx, portID, channelID, data.GenesisInfo.BaseCoinSupply())
-		if err != nil {
-			return 0, errorsmod.Wrap(err, "escrow genesis transfer funds")
-		}
-	}
-
 	bz, err := json.Marshal(data)
 	if err != nil {
 		return 0, errorsmod.Wrap(err, "marshal genesis bridge data")
@@ -106,7 +99,7 @@ func (w IBCModule) OnAcknowledgementPacket(
 ) error {
 	state := w.k.GetState(ctx)
 
-	// if outbound transfers are enabled, we past the genesis phase. nothing to do here.
+	// if canonical channel is set, we past the genesis phase. nothing to do here.
 	if state.CanonicalHubTransferChannelHasBeenSet() {
 		return w.IBCModule.OnAcknowledgementPacket(ctx, packet, acknowledgement, relayer)
 	}
@@ -124,42 +117,41 @@ func (w IBCModule) OnAcknowledgementPacket(
 		return errorsmod.Wrap(err, "check pending channel")
 	}
 	if !isPending {
-		// Not supposed to happen anyway
-		w.logger(ctx).Error("acknowledgement failed for unknown channel", "packet", packet, "ack", ack)
+		// Not supposed to happen
+		w.logger(ctx).Error("genesis bridge acknowledgement for unknown channel", "packet", packet, "ack", ack)
 		return errors.New("acknowledgement failed for unknown channel")
 	}
 
+	// Mark the channel as failed
 	if !ack.Success() {
 		w.logger(ctx).Error("acknowledgement failed for genesis transfer", "packet", packet, "ack", ack)
-
-		// Mark the channel for retry
 		portChan := types.PortAndChannel{Port: packet.SourcePort, Channel: packet.SourceChannel}
-		if err := w.k.SetPendingChannel(ctx, portChan, types.NeedsRetry); err != nil {
+		if err := w.k.SetPendingChannel(ctx, portChan, types.Failed); err != nil {
 			return errorsmod.Wrap(err, "set channel retry required")
-		}
-
-		var gbData types.GenesisBridgeData
-		err := json.Unmarshal(packet.Data, &gbData)
-		if err != nil {
-			return errorsmod.Wrap(err, "unmarshal genesis bridge data")
-		}
-
-		if gbData.GenesisTransfer != nil {
-			// unescrow and refund the funds
-			err = w.k.UnescrowGenesisTransferFunds(ctx, packet.SourcePort, packet.SourceChannel, gbData.GenesisInfo.BaseCoinSupply())
-			if err != nil {
-				return errorsmod.Wrap(err, "unescrow genesis transfer funds")
-			}
 		}
 
 		return nil
 	}
 
-	// If ack success, enable the bridge for the successful channel and clean up pending state
+	var gbData types.GenesisBridgeData
+	err = json.Unmarshal(packet.Data, &gbData)
+	if err != nil {
+		return errorsmod.Wrap(err, "unmarshal genesis bridge data")
+	}
+
+	if gbData.GenesisTransfer != nil {
+		// As we don't use the `ibc/transfer` module, we need to handle the funds escrow ourselves
+		err = w.k.EscrowGenesisTransferFunds(ctx, packet.SourcePort, packet.SourceChannel, gbData.GenesisInfo.BaseCoinSupply())
+		if err != nil {
+			return errorsmod.Wrap(err, "escrow genesis transfer funds")
+		}
+	}
+
+	w.k.enableBridge(ctx, state, packet.SourcePort, packet.SourceChannel)
+
 	if err := w.k.ClearPendingChannels(ctx); err != nil {
 		return errorsmod.Wrap(err, "clear pending channels")
 	}
-	w.k.enableBridge(ctx, state, packet.SourcePort, packet.SourceChannel)
 
 	ctx.EventManager().EmitEvent(sdk.NewEvent(types.EventTypeOutboundTransfersEnabled))
 	w.logger(ctx).Info("genesis bridge phase completed successfully")
@@ -180,37 +172,5 @@ func (w IBCModule) OnTimeoutPacket(
 		return w.IBCModule.OnTimeoutPacket(ctx, packet, relayer)
 	}
 
-	// validate it's a channel we are expecting
-	portChannel := types.PortAndChannel{Port: packet.SourcePort, Channel: packet.SourceChannel}
-	isPending, err := w.k.IsPendingChannel(ctx, portChannel)
-	if err != nil {
-		return errorsmod.Wrap(err, "check pending channel")
-	}
-	if !isPending {
-		// Not supposed to happen anyway
-		w.logger(ctx).Error("timeout for unknown channel", "packet", packet)
-		return errors.New("timeout for unknown channel")
-	}
-
-	// Mark the channel for retry
-	portChan := types.PortAndChannel{Port: packet.SourcePort, Channel: packet.SourceChannel}
-	if err := w.k.SetPendingChannel(ctx, portChan, types.NeedsRetry); err != nil {
-		return errorsmod.Wrap(err, "set channel retry required")
-	}
-
-	var gbData types.GenesisBridgeData
-	err = json.Unmarshal(packet.Data, &gbData)
-	if err != nil {
-		return errorsmod.Wrap(err, "unmarshal genesis bridge data")
-	}
-
-	if gbData.GenesisTransfer != nil {
-		// unescrow and refund the funds
-		err = w.k.UnescrowGenesisTransferFunds(ctx, packet.SourcePort, packet.SourceChannel, gbData.GenesisInfo.BaseCoinSupply())
-		if err != nil {
-			return errorsmod.Wrap(err, "unescrow genesis transfer funds")
-		}
-	}
-
-	return nil
+	return errorsmod.Wrapf(gerrc.ErrUnknown, "unexpected packet timeout: %s", packet.String())
 }

--- a/x/hub-genesis/keeper/ibc_module.go
+++ b/x/hub-genesis/keeper/ibc_module.go
@@ -146,7 +146,7 @@ func (w IBCModule) OnAcknowledgementPacket(
 		}
 	}
 
-	w.k.enableBridge(ctx, state, packet.SourcePort, packet.SourceChannel)
+	w.k.enableBridge(ctx, packet.SourcePort, packet.SourceChannel)
 
 	if err := w.k.ClearPendingChannels(ctx); err != nil {
 		return errorsmod.Wrap(err, "clear pending channels")

--- a/x/hub-genesis/keeper/keeper.go
+++ b/x/hub-genesis/keeper/keeper.go
@@ -27,8 +27,8 @@ type Keeper struct {
 
 	gb types.GenesisBridgeSubmitter
 
-	// key is port/channel. bool is types.ChannelState
-	OngoingChannels collections.Map[string, bool]
+	// key is port/channel. value is types.ChannelState
+	PendingChannels collections.Map[string, uint64]
 }
 
 func NewKeeper(
@@ -64,12 +64,12 @@ func NewKeeper(
 		bk:         bk,
 		mk:         mk,
 		gb:         gb,
-		OngoingChannels: collections.NewMap(
+		PendingChannels: collections.NewMap(
 			sb,
 			types.OngoingChannelsPrefix(),
 			"ongoing_channels",
 			collections.StringKey,
-			collections.BoolValue,
+			collections.Uint64Value,
 		),
 	}
 	return k
@@ -131,13 +131,13 @@ func (k Keeper) GetGenesisInfo(ctx sdk.Context) types.GenesisInfo {
 }
 
 func (k Keeper) SetPendingChannel(ctx sdk.Context, portChannel types.PortAndChannel, status types.ChannelState) error {
-	return k.OngoingChannels.Set(ctx, portChannel.Key(), bool(status))
+	return k.PendingChannels.Set(ctx, portChannel.Key(), uint64(status))
 }
 
 func (k Keeper) ClearPendingChannels(ctx sdk.Context) error {
-	return k.OngoingChannels.Clear(ctx, nil)
+	return k.PendingChannels.Clear(ctx, nil)
 }
 
 func (k Keeper) IsPendingChannel(ctx sdk.Context, portChannel types.PortAndChannel) (bool, error) {
-	return k.OngoingChannels.Has(ctx, portChannel.Key())
+	return k.PendingChannels.Has(ctx, portChannel.Key())
 }

--- a/x/hub-genesis/keeper/keeper.go
+++ b/x/hub-genesis/keeper/keeper.go
@@ -27,9 +27,8 @@ type Keeper struct {
 
 	gb types.GenesisBridgeSubmitter
 
-	// Collections-based state
-	// fixme: change bool to enum
-	OngoingChannels collections.Map[string, bool] // key is port/channel. bool is whether retransmission required
+	// key is port/channel. bool is types.ChannelState
+	OngoingChannels collections.Map[string, bool]
 }
 
 func NewKeeper(
@@ -131,8 +130,8 @@ func (k Keeper) GetGenesisInfo(ctx sdk.Context) types.GenesisInfo {
 	return gInfo
 }
 
-func (k Keeper) SetPendingChannel(ctx sdk.Context, portChannel types.PortAndChannel, retryRequired bool) error {
-	return k.OngoingChannels.Set(ctx, portChannel.Key(), retryRequired)
+func (k Keeper) SetPendingChannel(ctx sdk.Context, portChannel types.PortAndChannel, status types.ChannelState) error {
+	return k.OngoingChannels.Set(ctx, portChannel.Key(), bool(status))
 }
 
 func (k Keeper) ClearPendingChannels(ctx sdk.Context) error {

--- a/x/hub-genesis/keeper/keeper.go
+++ b/x/hub-genesis/keeper/keeper.go
@@ -141,3 +141,8 @@ func (k Keeper) ClearPendingChannels(ctx sdk.Context) error {
 func (k Keeper) IsPendingChannel(ctx sdk.Context, portChannel types.PortAndChannel) (bool, error) {
 	return k.PendingChannels.Has(ctx, portChannel.Key())
 }
+
+func (k Keeper) IsBridgeOpen(ctx sdk.Context) bool {
+	state := k.GetState(ctx)
+	return state.IsCanonicalBridgeOpen()
+}

--- a/x/hub-genesis/keeper/transfer_enable_ics4_wrapper.go
+++ b/x/hub-genesis/keeper/transfer_enable_ics4_wrapper.go
@@ -36,7 +36,7 @@ func (w ICS4Wrapper) SendPacket(
 	data []byte,
 ) (sequence uint64, err error) {
 	state := w.k.GetState(ctx)
-	if !state.OutboundTransfersEnabled {
+	if !state.CanonicalHubTransferChannelHasBeenSet() {
 		w.logger(ctx).Info("Transfer rejected: outbound transfers are disabled.")
 		return 0, errorsmod.Wrap(gerrc.ErrFailedPrecondition, "genesis phase not finished")
 	}

--- a/x/hub-genesis/keeper/transfer_enable_ics4_wrapper.go
+++ b/x/hub-genesis/keeper/transfer_enable_ics4_wrapper.go
@@ -35,8 +35,7 @@ func (w ICS4Wrapper) SendPacket(
 	timeoutTimestamp uint64,
 	data []byte,
 ) (sequence uint64, err error) {
-	state := w.k.GetState(ctx)
-	if !state.CanonicalHubTransferChannelHasBeenSet() {
+	if !w.k.IsBridgeOpen(ctx) {
 		w.logger(ctx).Info("Transfer rejected: outbound transfers are disabled.")
 		return 0, errorsmod.Wrap(gerrc.ErrFailedPrecondition, "genesis phase not finished")
 	}

--- a/x/hub-genesis/module.go
+++ b/x/hub-genesis/module.go
@@ -98,8 +98,7 @@ func (AppModuleBasic) GetQueryCmd() *cobra.Command {
 type AppModule struct {
 	AppModuleBasic
 
-	keeper                 keeper.Keeper
-	genesisBridgeSubmitter types.GenesisBridgeSubmitter
+	keeper keeper.Keeper
 }
 
 // NewAppModule creates a new AppModule object.

--- a/x/hub-genesis/module.go
+++ b/x/hub-genesis/module.go
@@ -98,7 +98,8 @@ func (AppModuleBasic) GetQueryCmd() *cobra.Command {
 type AppModule struct {
 	AppModuleBasic
 
-	keeper keeper.Keeper
+	keeper                 keeper.Keeper
+	genesisBridgeSubmitter types.GenesisBridgeSubmitter
 }
 
 // NewAppModule creates a new AppModule object.
@@ -157,6 +158,8 @@ func (am AppModule) ExportGenesis(ctx sdk.Context, cdc codec.JSONCodec) json.Raw
 
 // BeginBlock returns the begin blocker for the hub-genesis module.
 func (am AppModule) BeginBlock(ctx sdk.Context, _ abci.RequestBeginBlock) {
+	// Attempt to resubmit any pending genesis bridges
+	am.keeper.ResubmitPendingGenesisBridges(ctx)
 }
 
 // EndBlock returns the end blocker for the hub-genesis module. It returns no validator

--- a/x/hub-genesis/types/expected_keepers.go
+++ b/x/hub-genesis/types/expected_keepers.go
@@ -30,3 +30,7 @@ type BankKeeper interface {
 type MintKeeper interface {
 	MintDenom(ctx sdk.Context) string
 }
+
+type GenesisBridgeSubmitter interface {
+	SubmitGenesisBridgeData(ctx sdk.Context, portID string, channelID string) (seq uint64, err error)
+}

--- a/x/hub-genesis/types/keys.go
+++ b/x/hub-genesis/types/keys.go
@@ -1,5 +1,7 @@
 package types
 
+import "cosmossdk.io/collections"
+
 const (
 	ModuleName = "hubgenesis"
 
@@ -11,6 +13,11 @@ const (
 )
 
 var (
-	StateKey       = []byte{0x01}
-	GenesisInfoKey = []byte{0x02}
+	StateKey           = []byte{0x01}
+	GenesisInfoKey     = []byte{0x02}
+	OngoingChannelsKey = []byte{0x03}
 )
+
+func OngoingChannelsPrefix() collections.Prefix {
+	return collections.NewPrefix(OngoingChannelsKey)
+}

--- a/x/hub-genesis/types/state.go
+++ b/x/hub-genesis/types/state.go
@@ -1,8 +1,11 @@
 package types
 
 import (
+	"strings"
+
 	errorsmod "cosmossdk.io/errors"
 	host "github.com/cosmos/ibc-go/v6/modules/core/24-host"
+	gerrc "github.com/dymensionxyz/gerr-cosmos/gerrc"
 )
 
 func (s *State) Validate() error {
@@ -31,4 +34,22 @@ func (s *State) SetCanonicalTransferChannel(port, channel string) {
 		Port:    port,
 		Channel: channel,
 	}
+}
+
+// PortAndChannel
+func (p *PortAndChannel) Key() string {
+	return p.Port + "/" + p.Channel
+}
+
+// FromKey
+func FromPortAndChannelKey(key string) (PortAndChannel, error) {
+	port, channel, found := strings.Cut(key, "/")
+	if !found {
+		return PortAndChannel{}, errorsmod.Wrapf(gerrc.ErrInvalidArgument, "invalid port/channel key in onGoingChannels: %s", key)
+	}
+
+	return PortAndChannel{
+		Port:    port,
+		Channel: channel,
+	}, nil
 }

--- a/x/hub-genesis/types/state.go
+++ b/x/hub-genesis/types/state.go
@@ -32,15 +32,15 @@ func (s *State) Validate() error {
 	return nil
 }
 
-func (s *State) IsCanonicalHubTransferChannel(port, channel string) bool {
-	return s.CanonicalHubTransferChannelHasBeenSet() && s.HubPortAndChannel.Port == port && s.HubPortAndChannel.Channel == channel
+func (s *State) IsCanonicalBridgeChannel(port, channel string) bool {
+	return s.IsCanonicalBridgeOpen() && s.HubPortAndChannel.Port == port && s.HubPortAndChannel.Channel == channel
 }
 
-func (s *State) CanonicalHubTransferChannelHasBeenSet() bool {
+func (s *State) IsCanonicalBridgeOpen() bool {
 	return s.HubPortAndChannel != nil
 }
 
-func (s *State) SetCanonicalTransferChannel(port, channel string) {
+func (s *State) SetCanonicalBridgeChannel(port, channel string) {
 	s.HubPortAndChannel = &PortAndChannel{
 		Port:    port,
 		Channel: channel,

--- a/x/hub-genesis/types/state.go
+++ b/x/hub-genesis/types/state.go
@@ -9,13 +9,14 @@ import (
 )
 
 // ChannelState represents the state of a channel in the genesis bridge process
-type ChannelState bool
+type ChannelState uint64
 
 const (
+	Undefined ChannelState = 0
 	// WaitingForAck indicates the channel is waiting for acknowledgment
-	WaitingForAck ChannelState = false
-	// NeedsRetry indicates the channel needs to retry the genesis bridge
-	NeedsRetry ChannelState = true
+	WaitingForAck ChannelState = 1
+	// Failed indicates the channel has failed and can be retried
+	Failed ChannelState = 2
 )
 
 func (s *State) Validate() error {

--- a/x/hub-genesis/types/state.go
+++ b/x/hub-genesis/types/state.go
@@ -8,6 +8,16 @@ import (
 	gerrc "github.com/dymensionxyz/gerr-cosmos/gerrc"
 )
 
+// ChannelState represents the state of a channel in the genesis bridge process
+type ChannelState bool
+
+const (
+	// WaitingForAck indicates the channel is waiting for acknowledgment
+	WaitingForAck ChannelState = false
+	// NeedsRetry indicates the channel needs to retry the genesis bridge
+	NeedsRetry ChannelState = true
+)
+
 func (s *State) Validate() error {
 	if s.HubPortAndChannel != nil {
 		if err := host.PortIdentifierValidator(s.HubPortAndChannel.Port); err != nil {


### PR DESCRIPTION
Allows 
* attempt multiple channels until success (instead of the first channel)
* genesis bridge retries

----

```
the hub sets the canonical channel by the SetCanonicalTx
in current desing in the RDK,
it tries once on the first channel.
-----
there are multiple use cases (the relayer supposed to mitigate most):
invalid client + channel created - the client will never be canonical, and the rollapp is unrecovable
valid client + channel, but it’s not set canonical yet - the genesis bridge will fail, and the rollapp is unrecovarable
----
to mitigate:
rdk will set channel as canonical, once it acked succesfully
it will retry over each existing channel until that
```