### PR TITLE
fix(epochs): counting epoch from first block rather than genesis time

### DIFF
--- a/x/epochs/keeper/abci.go
+++ b/x/epochs/keeper/abci.go
@@ -27,6 +27,7 @@ func (k Keeper) BeginBlocker(ctx sdk.Context) {
 
 		switch {
 		case shouldInitialEpochStart:
+			epochInfo.StartTime = ctx.BlockTime() // a hack so epochs will start in regard of the first block, instead of the genesis time
 			epochInfo = startInitialEpoch(epochInfo)
 			logger.Info(fmt.Sprintf("initial %s epoch", epochInfo.Identifier))
 		case shouldEpochStart:


### PR DESCRIPTION
epochs counting starts from first block instead of genesis time