### PR TITLE
fix typo in 02_state.md

### DIFF
--- a/x/gasless/spec/02_state.md
+++ b/x/gasless/spec/02_state.md
@@ -87,7 +87,7 @@ message GasConsumer {
     // bech32 encoded address of the consumer
     string consumer = 1;
 
-    // consumtion statistics of the consumer
+    // consumption statistics of the consumer
     repeated ConsumptionDetail consumptions = 2;
 }
 ```


### PR DESCRIPTION
# Pull Request Template: Fixing Typo in `02_state.md`

## Title
**Fix Typo in `02_state.md`**

## Description
This PR corrects a typo in the `02_state.md` file. The word `consumtion` has been fixed to `consumption` for accuracy and consistency in the documentation.

### Changes Made:
- Corrected `consumtion` to `consumption` in the `02_state.md` file.

## Reason for Change
Fixing this typo helps maintain clear and precise documentation, which is essential for the project's understanding and use.

## Checklist
Please confirm the following before submitting:
- [x] I have reviewed the changes to ensure they align with the repository’s contributing guidelines.
- [x] This PR adheres to the security policy and code of conduct.
- [x] I have included a clear and concise description of the changes.
- [x] Edits by maintainers are allowed for this PR.

## Additional Notes
- This PR only addresses a typo fix and does not introduce any other changes to the content.
