### PR TITLE
chore: fix typo in app.go

### DIFF
--- a/testutil/app/app.go
+++ b/testutil/app/app.go
@@ -478,7 +478,7 @@ func NewRollapp(
 		app.IBCKeeper.ChannelKeeper,
 	)
 
-	// The IBC tranfer submit is wrapped with:
+	// The IBC transfer submit is wrapped with:
 	var ics4Wrapper ibcporttypes.ICS4Wrapper
 	// - denom metadata middleware
 	ics4Wrapper = denommetadata.NewICS4Wrapper(


### PR DESCRIPTION
Corrected "tranfer" to "transfer" in app.go.