### PR TITLE
Typo fix README.md

### DIFF
--- a/x/tokenfactory/README.md
+++ b/x/tokenfactory/README.md
@@ -81,7 +81,7 @@ message MsgBurn {
 
 **State Modifications:**
 
-- Saftey check the following
+- Safety check the following
   - Check that the denom minting is created via `tokenfactory` module
   - Check that the sender of the message is the admin of the denom
 - Burn designated amount of tokens for the denom via `bank` module


### PR DESCRIPTION
Corrected "Saftey" to "Safety" under the State Modifications section.